### PR TITLE
Fixed autoloading with composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,6 @@
         "psr-0": {
             "PHPGoogleMaps": ""
         }
-    }
+    },
+    "target-dir": "PHPGoogleMaps"
 }


### PR DESCRIPTION
To make autoloading with composer work, package needs to be installed in the PHPGoogleMaps directory (to follow PSR-0 standard).
