### PR TITLE
Fixed directions unitSystem option rendering

### DIFF
--- a/Map.php
+++ b/Map.php
@@ -1228,7 +1228,7 @@ class Map {
 	 * @return void
 	 */
 	public function setUnitsMetric() {
-		$this->setUnits( 'metric' );
+		$this->setUnits( 'METRIC' );
 	}
 
 	/**
@@ -1237,7 +1237,7 @@ class Map {
 	 * @return void
 	 */
 	public function setUnitsImperial() {
-		$this->setUnits( 'imperial' );
+		$this->setUnits( 'IMPERIAL' );
 	}
 
 	/**
@@ -1940,7 +1940,7 @@ class Map {
 					  	$request_options .= sprintf( "\t\ttravelMode: google.maps.DirectionsTravelMode.%s,\n", strtoupper( $this->directions->request_options['travelMode'] ) );
 					  	break;
 					case 'units':
-					  	$request_options .= sprintf( "\t\tunitSystem: google.maps.DirectionsUnitSystem.%s,\n", isset( $this->directions->request_options['units'] ) ?: $this->units );
+					  	$request_options .= sprintf( "\t\tunitSystem: google.maps.DirectionsUnitSystem.%s,\n", isset( $this->directions->request_options['units'] ) ? $this->directions->request_options['units'] : $this->units );
 						break;
 		  			default:
 		  				$request_options .= sprintf( "\t\t%s:%s,\n", $request_option, $this->phpToJs( $request_value ) );


### PR DESCRIPTION
When the `$this->directions->request_options['units']` option is defined `getMapJS` method rendered this javascript code:

``` javascript
{
unitSystem: google.maps.DirectionsUnitSystem.1
}
```

Obviously this is wrong.

Also 'imperial' and 'metric' string literals should be uppercase. Because `google.maps.DirectionsUnitSystem` contains `IMPERIAL` and `METRIC` constants but not `imperial` and `metric`.
