### PR TITLE
Corrected namespace PHPGoogleMaps\overlay to namespace PHPGoogleMaps\Overlay

### DIFF
--- a/Overlay/MarkerGroup.php
+++ b/Overlay/MarkerGroup.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PHPGoogleMaps\overlay;
+namespace PHPGoogleMaps\Overlay;
 
 /**
  * Marker group class

--- a/Overlay/MarkerIcon.php
+++ b/Overlay/MarkerIcon.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PHPGoogleMaps\overlay;
+namespace PHPGoogleMaps\Overlay;
 
 /**
  * Marker Icon class


### PR DESCRIPTION
Fixed an issue where the namespace had a lowercase O for overlay. This was causing issues in a silex application that I am working on.

The code complaining about this issue is here https://github.com/symfony/Debug/blob/master/DebugClassLoader.php

This was error I was getting:

```
[2014-00-00 00:00:00] web.CRITICAL: RuntimeException: Case mismatch between loaded and declared class names: PHPGoogleMaps\Overlay\MarkerIcon vs PHPGoogleMaps\overlay\MarkerIcon (uncaught exception) at /var/www/web/vendor/symfony/debug/Symfony/Component/Debug/DebugClassLoader.php line 179 {"exception":"[object] (RuntimeException: Case mismatch between loaded and declared class names: PHPGoogleMaps\\Overlay\\MarkerIcon vs PHPGoogleMaps\\overlay\\MarkerIcon at /var/www/web/vendor/symfony/debug/Symfony/Component/Debug/DebugClassLoader.php:179)"} []
```
