### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#PHP Google Maps API
+# PHP Google Maps API
 
 For PHP 5.3+ and Google Maps API v3
 
-##Features
+## Features
  - Adsense ads
  - Binding map objects
  - Custom map controls
@@ -28,7 +28,7 @@ For PHP 5.3+ and Google Maps API v3
  - Streetview
  - Simple configuration of map objects
 
-##Autoloading
+## Autoloading
 
 Use the included autoloader
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
